### PR TITLE
feat: DATA-11184 Add missing fields to the Template form and tooltips

### DIFF
--- a/src/components/DescriptionGenerator/AiResults.tsx
+++ b/src/components/DescriptionGenerator/AiResults.tsx
@@ -5,9 +5,10 @@ import { type Result } from "./types";
 interface AiResultsProps {
     results: Result[];
     onChange(index: number, description: string): void;
+    generateDescription(): Promise<void>;
 }
 
-export default function AiResults({ results, onChange }: AiResultsProps) {
+export default function AiResults({ results, onChange, generateDescription }: AiResultsProps) {
     const [page, setPage] = useState(results.length);
 
     const currentResult = results.at(page - 1);
@@ -34,8 +35,9 @@ export default function AiResults({ results, onChange }: AiResultsProps) {
             </Flex>
             <Small marginTop="medium">{currentResult.promptAttributes}</Small>
             <Textarea onChange={handleValueChange} value={currentResult.description} />
-            {/* <Button mobileWidth="auto" variant="secondary" onClick={() => void generateDescription()}>Try Again</Button> */}
-            <Button marginTop="medium" variant="secondary">Try Again</Button>
+            <Flex paddingTop="medium">
+                <Button variant="secondary" onClick={() => void generateDescription()}>Try Again</Button>
+            </Flex>
         </Flex>
     );
 }

--- a/src/components/DescriptionGenerator/DescriptionGenerator.tsx
+++ b/src/components/DescriptionGenerator/DescriptionGenerator.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, FlexItem } from "@bigcommerce/big-design";
+import { Flex, FlexItem } from "@bigcommerce/big-design";
 import Loader from "../Loader";
 import AiResults from "./AiResults";
 import { PromptForm } from "./PromptForm";
@@ -9,8 +9,8 @@ interface DescriptionGeneratorProps {
     isLoading: boolean;
     results: Result[];
     setPromptAttributes(attributes: PromptAttributes): void;
-    onDescriptionChange: (index: number, description: string) => void;
-    generateDescription: () => Promise<void>;
+    onDescriptionChange(index: number, description: string): void;
+    generateDescription(): Promise<void>;
 }
 
 export function DescriptionGenerator({ isLoading, results, setPromptAttributes, onDescriptionChange, generateDescription }: DescriptionGeneratorProps) {
@@ -26,7 +26,7 @@ export function DescriptionGenerator({ isLoading, results, setPromptAttributes, 
             {isLoading && <Loader />}
             {!isLoading &&
                 <FlexItem flexGrow={1}>
-                    <AiResults onChange={onDescriptionChange} results={results} />
+                    <AiResults onChange={onDescriptionChange} generateDescription={generateDescription} results={results} />
                 </FlexItem>
             }
         </Flex>

--- a/src/components/DescriptionGenerator/PromptForm/TemplatePromptForm.tsx
+++ b/src/components/DescriptionGenerator/PromptForm/TemplatePromptForm.tsx
@@ -1,7 +1,20 @@
 import { type TemplatePromptAttributes } from '../types';
-import { useState } from 'react';
-import { Checkbox, Collapse, Counter, FormGroup, Input, Select } from '@bigcommerce/big-design';
+import React, { useState } from 'react';
+import {
+    Checkbox,
+    Collapse,
+    Counter,
+    FormGroup,
+    Text,
+    Input,
+    Select,
+    CheckboxLabel,
+    FormControlLabel,
+    Tooltip,
+    Flex
+} from '@bigcommerce/big-design';
 import { type PromptFormProps } from '~/components/DescriptionGenerator/PromptForm/types';
+import { BaselineHelpIcon } from '@bigcommerce/big-design-icons';
 
 type InputFieldValue = string | number | boolean | undefined;
 
@@ -21,8 +34,27 @@ const DEFAULT_PROMPT_ATTRIBUTES: TemplatePromptAttributes = {
     includeProductAttributes: true,
     optimizedForSeo: true,
     brandVoice: '',
-    additionalAttributes: ''
+    additionalAttributes: '',
+    keywords: '',
+    instructions: '',
   };
+
+interface InputLabelProps {
+    text: string;
+    tooltip: string;
+    bold: boolean;
+}
+
+export const InputLabel = ({ text, tooltip, bold }: InputLabelProps) => (
+    <Flex flexDirection="row" marginBottom="xxSmall" alignItems="center">
+        <Text as="span" bold={bold} marginBottom="none" marginRight="xxSmall">
+            {text}
+        </Text>
+        <Tooltip placement="right" trigger={<BaselineHelpIcon color="secondary50" size="large" />}>
+            {tooltip}
+        </Tooltip>
+    </Flex>
+);
 
 export function TemplatePromptForm({ onChange }: PromptFormProps) {
     const [formAttributes, setFormAttributes] = useState(DEFAULT_PROMPT_ATTRIBUTES);
@@ -75,14 +107,30 @@ export function TemplatePromptForm({ onChange }: PromptFormProps) {
                 <FormGroup>
                     <Checkbox
                         checked={formAttributes.includeProductAttributes}
-                        label="Include product information"
+                        label={
+                            <CheckboxLabel>
+                                <InputLabel
+                                    bold={false}
+                                    text="Include product information"
+                                    tooltip="If checked, the description will feature information from the product page for this product. This includes: product name, product type, brand, dimensions and weight, categories and condition."
+                                />
+                            </CheckboxLabel>
+                        }
                         onChange={() => handleInputChange(!formAttributes.includeProductAttributes, 'includeProductAttributes')}
                     />
                 </FormGroup>
                 <FormGroup>
                     <Input
                         value={formAttributes.brandVoice}
-                        label="Brand voice"
+                        label={
+                            <FormControlLabel>
+                                <InputLabel
+                                    bold={true}
+                                    text="Brand voice"
+                                    tooltip="Enter the words that best describe the personality of your brand. For example, “upbeat and confident” or “friendly and conversational.”"
+                                />
+                            </FormControlLabel>
+                        }
                         placeholder="Upbeat, positive, and fun"
                         onChange={(event) => handleInputChange(event.target.value, 'brandVoice')}
                     />
@@ -90,9 +138,48 @@ export function TemplatePromptForm({ onChange }: PromptFormProps) {
                 <FormGroup>
                     <Input
                         value={formAttributes.additionalAttributes}
-                        label="Attributes"
+                        label={
+                            <FormControlLabel>
+                                <InputLabel
+                                    bold={true}
+                                    text="Attributes"
+                                    tooltip="Enter any words or phrases that help describe or differentiate this product in addition to what is already mentioned on the product information page. You should enter attributes as key-value pairs. For example, “color: red” or “material: recycled cotton”."
+                                />
+                            </FormControlLabel>
+                        }
                         placeholder="Organic, recycled cotton"
                         onChange={(event) => handleInputChange(event.target.value, 'additionalAttributes')}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Input
+                        value={formAttributes.keywords}
+                        label={
+                            <FormControlLabel>
+                                <InputLabel
+                                    bold={true}
+                                    text="Keywords"
+                                    tooltip="Enter any words or phrases that you want to make sure are included in the description."
+                                />
+                            </FormControlLabel>
+                        }
+                        onChange={(event) => handleInputChange(event.target.value, 'keywords')}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Input
+                        value={formAttributes.instructions}
+                        label={
+                            <FormControlLabel>
+                                <InputLabel
+                                    bold={true}
+                                    text="Instructions"
+                                    tooltip="Enter any additional instructions, e.g. “do not use word X“ or “no capital letters“"
+                                    // TODO: Change tooltip copy once the design is ready
+                                />
+                            </FormControlLabel>
+                        }
+                        onChange={(event) => handleInputChange(event.target.value, 'instructions')}
                     />
                 </FormGroup>
             </Collapse>

--- a/src/components/DescriptionGenerator/types.ts
+++ b/src/components/DescriptionGenerator/types.ts
@@ -9,6 +9,8 @@ export interface TemplatePromptAttributes {
     optimizedForSeo: boolean;
     brandVoice: string;
     additionalAttributes: string;
+    keywords: string;
+    instructions: string;
     includeProductAttributes: boolean;
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,6 @@ export default function Home() {
     <Panel header="Control Panel AI App">
       <Flex flexDirection="column">
         <Link href="/productAppExtension/1">App extension option</Link>
-        <Link href="/modal-option">Modal option</Link>
       </Flex>
     </Panel>
   );

--- a/src/pages/productAppExtension/[productId].tsx
+++ b/src/pages/productAppExtension/[productId].tsx
@@ -12,7 +12,9 @@ const DEFAULT_PROMPT_ATTRIBUTES: TemplatePromptAttributes = {
   includeProductAttributes: true,
   optimizedForSeo: true,
   brandVoice: '',
-  additionalAttributes: ''
+  additionalAttributes: '',
+  keywords: '',
+  instructions: '',
 };
 
 function ProductAppExtensionContent({ productId = 1 }) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -5,14 +5,16 @@ interface KeyToLabelMap {
   }
 
 const KEY_TO_LABEL_MAP: KeyToLabelMap = {
-    style: 'Style',
-    includeProductAttributes: 'Include product attributes',
-    wordCount: 'Words',
-    optimizedForSeo: 'Optimized for SEO',
-    brandVoice: 'Brand voice',
-    additionalAttributes: 'Attributes',
-    customPrompt: 'Instructions',
-}
+        style: 'Style',
+        includeProductAttributes: 'Include product attributes',
+        wordCount: 'Words',
+        optimizedForSeo: 'Optimized for SEO',
+        brandVoice: 'Brand voice',
+        additionalAttributes: 'Attributes',
+        customPrompt: 'Instructions',
+        keywords: 'Keywords',
+        instructions: 'Instructions',
+    }
 
 export const serializePromptAttributes = (promptAttributes: PromptAttributes): string => {
     let result = '';


### PR DESCRIPTION
## What/Why?
- Add `Keywords` and `Instructions` fields into `Template` prompt form
- Add tooltips for all fields (tooltip for the `Instructions` field to be changed once there is a copy in the design)

## Testing
Manually

https://github.com/bigcommerce/control-panel-ai-app/assets/94108505/d86c34f0-b501-4e56-b3ba-d2bb97084d5f



@bigcommerce/data-team
