### PR TITLE
fix: DATA-000 Minor layout fixes

### DIFF
--- a/src/components/AiResults/AiResults.tsx
+++ b/src/components/AiResults/AiResults.tsx
@@ -26,7 +26,7 @@ export default function AiResults({ results, onChange }: AiResultsProps) {
 
     return (
         <Flex marginTop="large" flexDirection="column">
-            <Grid gridColumns="repeat(2, 1fr)" marginBottom="medium">
+            <Grid gridColumns="1fr 4fr" marginBottom="medium" gridColumnGap="0">
                 <Flex flexDirection="row" alignItems="center">
                     <H3 marginBottom="none">Results</H3>
                 </Flex>

--- a/src/components/PromptForm/StructuredPromptForm.tsx
+++ b/src/components/PromptForm/StructuredPromptForm.tsx
@@ -66,7 +66,7 @@ export function StucturedPromptForm({ attributes, onChange }: StructuredFormProp
                     />
                 </FormGroup>
                 <FormGroup>
-                    <Flex flexDirection="row" alignItems="flex-end" paddingBottom="large">
+                    <Flex flexDirection="row" alignItems="center">
                         <Checkbox
                             checked={attributes.optimizedForSeo}
                             label={

--- a/src/containers/DescriptionGenerator.tsx
+++ b/src/containers/DescriptionGenerator.tsx
@@ -52,7 +52,7 @@ export default function DescriptonGenerator({ product }: DescriptonGeneratorProp
     };
 
     return (
-        <FullScreenHeightWrapper flexDirection="column" justifyContent="space-between" padding="xLarge">
+        <FullScreenHeightWrapper flexDirection="column" justifyContent="space-between" padding="xSmall">
             <FullSizeContainer flexDirection="column">
                 <FlexItem>
                     <Box display="inline-flex" marginBottom="large">


### PR DESCRIPTION
## What?
- Change align for the SEO checkbox
- Reduce main wrapper padding to take the side panel's padding into account
- Fix pagination width

## Why?
As per testing on prod in a real side panel, we've detected a couple of layout issues.

## Testing / Proof
Manually
<img width="288" alt="image" src="https://github.com/bigcommerce/ai-app-foundation/assets/94108505/a32d8180-5342-47f2-8183-c78219975e1a">


@bigcommerce/team-data
