### PR TITLE
Update sentry/nextjs to 7.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bigcommerce/big-design-theme": "^0.19.2",
         "@google-ai/generativelanguage": "^0.2.1",
         "@segment/snippet": "^4.16.2",
-        "@sentry/nextjs": "^7.65.0",
+        "@sentry/nextjs": "^7.77.0",
         "@t3-oss/env-nextjs": "^0.3.1",
         "@tinymce/tinymce-react": "^4.3.0",
         "@types/fs-extra": "^11.0.2",
@@ -1782,30 +1782,28 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.65.0.tgz",
-      "integrity": "sha512-TEYkiq5vKr1Y79YIu+UYr1sO3vEMttQOBsOZLziDbqiC7TvKUARBR4W5XWfb9qBVDeon87EFNKluW0/+7rzYWw==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.77.0.tgz",
+      "integrity": "sha512-8HRF1rdqWwtINqGEdx8Iqs9UOP/n8E0vXUu3Nmbqj4p5sQPA7vvCfq+4Y4rTqZFc7sNdFpDsRION5iQEh8zfZw==",
       "dependencies": {
-        "@sentry/core": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.65.0.tgz",
-      "integrity": "sha512-TUzZPAXNJ/Y1yakFODYhsEtdDpLdkgjTfrx5i9MOnXQLrcRR0C4TC1KitqbP6Tv7Xha9WiR0TDZkh7gS/9RxEA==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.77.0.tgz",
+      "integrity": "sha512-nJ2KDZD90H8jcPx9BysQLiQW+w7k7kISCWeRjrEMJzjtge32dmHA8G4stlUTRIQugy5F+73cOayWShceFP7QJQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.65.0",
-        "@sentry/core": "7.65.0",
-        "@sentry/replay": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.77.0",
+        "@sentry/core": "7.77.0",
+        "@sentry/replay": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0"
       },
       "engines": {
         "node": ">=8"
@@ -1843,54 +1841,55 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.65.0.tgz",
-      "integrity": "sha512-EwZABW8CtAbRGXV69FqeCqcNApA+Jbq308dko0W+MFdFe+9t2RGubUkpPxpJcbWy/dN2j4LiuENu1T7nWn0ZAQ==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.77.0.tgz",
+      "integrity": "sha512-Tj8oTYFZ/ZD+xW8IGIsU6gcFXD/gfE+FUxUaeSosd9KHwBQNOLhZSsYo/tTVf/rnQI/dQnsd4onPZLiL+27aTg==",
       "dependencies": {
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.65.0.tgz",
-      "integrity": "sha512-9b54p0UrkWe9+RAWWTObJQ2k/uStqaUj7BkNFyuaxfKQ4IZViqc4Sa7d7zX2X1oynGNL3ic7iqcgVTh7NvNsAQ==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.77.0.tgz",
+      "integrity": "sha512-P055qXgBHeZNKnnVEs5eZYLdy6P49Zr77A1aWJuNih/EenzMy922GOeGy2mF6XYrn1YJSjEwsNMNsQkcvMTK8Q==",
       "dependencies": {
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "localforage": "^1.8.1",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "7.65.0",
-      "integrity": "sha512-/Pyuf+UKyIA3GXnqRiLv6qZIT0lsN0BHAB67Is/GaQlYA+0zsqSYX24HGqAJ6U3bz+6d9W0dX5AmyVwobH9Vdg==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.77.0.tgz",
+      "integrity": "sha512-8tYPBt5luFjrng1sAMJqNjM9sq80q0jbt6yariADU9hEr7Zk8YqFaOI2/Q6yn9dZ6XyytIRtLEo54kk2AO94xw==",
       "dependencies": {
         "@rollup/plugin-commonjs": "24.0.0",
-        "@sentry/core": "7.65.0",
-        "@sentry/integrations": "7.65.0",
-        "@sentry/node": "7.65.0",
-        "@sentry/react": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
+        "@sentry/core": "7.77.0",
+        "@sentry/integrations": "7.77.0",
+        "@sentry/node": "7.77.0",
+        "@sentry/react": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0",
+        "@sentry/vercel-edge": "7.77.0",
         "@sentry/webpack-plugin": "1.20.0",
         "chalk": "3.0.0",
+        "resolve": "1.22.8",
         "rollup": "2.78.0",
-        "stacktrace-parser": "^0.1.10",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "stacktrace-parser": "^0.1.10"
       },
       "engines": {
         "node": ">=8"
       },
       "peerDependencies": {
-        "next": "^10.0.8 || ^11.0 || ^12.0 || ^13.0",
+        "next": "^10.0.8 || ^11.0 || ^12.0 || ^13.0 || ^14.0",
         "react": "16.x || 17.x || 18.x",
         "webpack": ">= 4.0.0"
       },
@@ -1913,33 +1912,29 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.65.0.tgz",
-      "integrity": "sha512-zRCHOO7vIQukgFdEib3X7nP7HA9Uyc/o4QMtBnAREaYKzERGRnArvaB3Na0bXsuLVCOELoCAlrzFH3apmgxBQw==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.77.0.tgz",
+      "integrity": "sha512-Ob5tgaJOj0OYMwnocc6G/CDLWC7hXfVvKX/ofkF98+BbN/tQa5poL+OwgFn9BA8ud8xKzyGPxGU6LdZ8Oh3z/g==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.65.0",
-        "@sentry/core": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/tracing": "7.77.0",
+        "@sentry/core": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0",
+        "https-proxy-agent": "^5.0.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.65.0.tgz",
-      "integrity": "sha512-1ABxHwEHw5J4avUr8TBch3l7UszbNIroWergwiLPSy+EJU8WuB3Fdx0zSU+hS4Sujf8HNcRgu1JyWThZFTnIMA==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.77.0.tgz",
+      "integrity": "sha512-Q+htKzib5em0MdaQZMmPomaswaU3xhcVqmLi2CxqQypSjbYgBPPd+DuhrXKoWYLDDkkbY2uyfe4Lp3yLRWeXYw==",
       "dependencies": {
-        "@sentry/browser": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/browser": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -1949,33 +1944,46 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.65.0.tgz",
-      "integrity": "sha512-vhlk5F9RrhMQ+gOjNlLoWXamAPLNIT6wNII1O9ae+DRhZFmiUYirP5ag6dH5lljvNZndKl+xw+lJGJ3YdjXKlQ==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.77.0.tgz",
+      "integrity": "sha512-M9Ik2J5ekl+C1Och3wzLRZVaRGK33BlnBwfwf3qKjgLDwfKW+1YkwDfTHbc2b74RowkJbOVNcp4m8ptlehlSaQ==",
       "dependencies": {
-        "@sentry/core": "7.65.0",
-        "@sentry/types": "7.65.0",
-        "@sentry/utils": "7.65.0"
+        "@sentry-internal/tracing": "7.77.0",
+        "@sentry/core": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.65.0.tgz",
-      "integrity": "sha512-YYq7IDLLhpSBTmHoyWFtq/5ZDaEJ01r7xGuhB0aSIq33cm2I7im/B3ipzoOP/ukGZSIhuYVW9t531xZEO0+6og==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.77.0.tgz",
+      "integrity": "sha512-nfb00XRJVi0QpDHg+JkqrmEBHsqBnxJu191Ded+Cs1OJ5oPXEW6F59LVcBScGvMqe+WEk1a73eH8XezwfgrTsA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.65.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.65.0.tgz",
-      "integrity": "sha512-2JEBf4jzRSClhp+LJpX/E3QgHEeKvXqFMeNhmwQ07qqd6szhfH2ckYFj4gXk6YiGGY4Act3C6oxLfdZovG71bw==",
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.77.0.tgz",
+      "integrity": "sha512-NmM2kDOqVchrey3N5WSzdQoCsyDkQkiRxExPaNI2oKQ/jMWHs9yt0tSy7otPBcXs0AP59ihl75Bvm1tDRcsp5g==",
       "dependencies": {
-        "@sentry/types": "7.65.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.77.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/vercel-edge": {
+      "version": "7.77.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-7.77.0.tgz",
+      "integrity": "sha512-ffddPCgxVeAccPYuH5sooZeHBqDuJ9OIhIRYKoDi4TvmwAzWo58zzZWhRpkHqHgIQdQvhLVZ5F+FSQVWnYSOkw==",
+      "dependencies": {
+        "@sentry/core": "7.77.0",
+        "@sentry/types": "7.77.0",
+        "@sentry/utils": "7.77.0"
       },
       "engines": {
         "node": ">=8"
@@ -3204,14 +3212,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "peer": true
     },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/copy-anything": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
@@ -3889,23 +3889,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.12.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4479,10 +4462,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
@@ -5228,6 +5213,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -5432,12 +5428,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-      "dev": true,
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6177,11 +6172,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6765,8 +6755,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7254,12 +7243,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7989,7 +7977,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@bigcommerce/big-design-theme": "^0.19.2",
     "@google-ai/generativelanguage": "^0.2.1",
     "@segment/snippet": "^4.16.2",
-    "@sentry/nextjs": "^7.65.0",
+    "@sentry/nextjs": "^7.77.0",
     "@t3-oss/env-nextjs": "^0.3.1",
     "@tinymce/tinymce-react": "^4.3.0",
     "@types/fs-extra": "^11.0.2",


### PR DESCRIPTION
## What?

Update `sentry/nextjs` to `^7.77.0`

## Why?

Security vulnerability in earlier versions.

## Testing / Proof

CircleCI.

@bigcommerce/team-data
