### PR TITLE
fix: DATA-11516 Add targetOrigin for postMessage calls

### DIFF
--- a/src/app/productDescription/[productId]/form.tsx
+++ b/src/app/productDescription/[productId]/form.tsx
@@ -64,10 +64,16 @@ export default function Form({ product }: { product: Product | NewProduct }) {
     updateDescriptionInHistory(index, description);
   };
 
+  const getStoreURL = () => {
+    const suffix = process.env.NODE_ENV === 'production' ? 'mybigcommerce.com' : 'store.bcdev';
+
+    return `https://store-${storeHash}.${suffix}`;
+  };
+
   const handleCancelClick = () => {
     window.top?.postMessage(
       JSON.stringify({ namespace: 'APP_EXT', action: 'CLOSE' }),
-      '*'
+      getStoreURL()
     );
     trackClick({ context, locale, storeHash, action: 'Cancel' });
   };
@@ -78,7 +84,7 @@ export default function Form({ product }: { product: Product | NewProduct }) {
         action: 'PRODUCT_DESCRIPTION',
         data: { description },
       }),
-      '*'
+      getStoreURL()
     );
     trackSubmit({
       context,


### PR DESCRIPTION
## What?
Per title

## Why?
Currently we are passing a wildcard (`*`) as a target when calling the `window.postMessage` method. This allows attackers to intercept the messages. So that we need to specify target which should be current store's CP url.

## Testing / Proof
Manually tested on prod store. Verified both dev and prod environments. Verified that the messages e.g. `Cancel` or `Use this` button click are only intercepted when the store URL is correct. F.e. on prod store when the app is running in dev mode, the buttons won't do anything.

@bigcommerce/team-data
