### PR TITLE
fix: DATA-11515 Add csrf protection for the generateDescription api endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/styled-components": "^5.1.26",
         "@types/tinymce": "^4.6.6",
         "@vercel/analytics": "^1.0.2",
+        "edge-csrf": "^1.0.7",
         "firebase": "^9.23.0",
         "fs-extra": "^11.1.1",
         "google-auth-library": "^8.9.0",
@@ -3488,6 +3489,14 @@
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/edge-csrf": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/edge-csrf/-/edge-csrf-1.0.7.tgz",
+      "integrity": "sha512-Bwf5FQqtJH/wbEd7uu3mv0go+chulIWwmqINUzVbvdsCno78GLTs7epEvS6EiKSHgmzg7HDFSaGx89cFRvlmNw==",
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/tinymce": "^4.6.6",
     "@vercel/analytics": "^1.0.2",
+    "edge-csrf": "^1.0.7",
     "firebase": "^9.23.0",
     "fs-extra": "^11.1.1",
     "google-auth-library": "^8.9.0",

--- a/src/app/productDescription/[productId]/form.tsx
+++ b/src/app/productDescription/[productId]/form.tsx
@@ -12,10 +12,9 @@ import Loader from '~/components/Loader';
 import { useAppContext } from '~/context/AppContext';
 import { useTracking } from '~/hooks/useTracking';
 
-export default function Form({ product }: { product: Product | NewProduct }) {
+export default function Form({ product, csrfToken }: { product: Product | NewProduct; csrfToken: string }) {
   const { descriptions, addDescriptionToHistory, updateDescriptionInHistory } =
     useDescriptionsHistory(product.id);
-
   const [isLoading, setIsLoading] = useState(false);
   const [description, setDescription] = useState(
     descriptions.at(-1)?.description || ''
@@ -41,6 +40,9 @@ export default function Form({ product }: { product: Product | NewProduct }) {
       body: JSON.stringify(
         prepareAiPromptAttributes(currentAttributes, product)
       ),
+      headers: {
+        'X-CSRF-Token': csrfToken,
+      },
     });
 
     if (!res.ok) {

--- a/src/app/productDescription/[productId]/generator.tsx
+++ b/src/app/productDescription/[productId]/generator.tsx
@@ -12,11 +12,13 @@ export default function Generator({
   storeHash,
   locale,
   context,
+  csrfToken
 }: {
   product: Product | NewProduct;
   storeHash: string;
   locale: string;
   context: string;
+  csrfToken: string;
 }) {
   const [isClient, setIsClient] = useState(false);
 
@@ -31,7 +33,7 @@ export default function Generator({
       {isClient && (
         <AppContext.Provider value={{ locale, storeHash, context }}>
           <PromptAttributesProvider>
-            <Form product={product} />
+            <Form product={product} csrfToken={csrfToken} />
           </PromptAttributesProvider>
         </AppContext.Provider>
       )}

--- a/src/app/productDescription/[productId]/page.tsx
+++ b/src/app/productDescription/[productId]/page.tsx
@@ -33,12 +33,15 @@ export default async function Page(props: PageProps) {
       ? { id, name: name || '' }
       : await fetchProductWithAttributes(id, accessToken, authorized.storeHash);
 
+  const csrfToken = headers().get('X-CSRF-Token') || 'missing';
+
   return (
     <Generator
       locale={headers().get('Accept-Language')?.split(',')[0] || ''}
       storeHash={authorized.storeHash}
       product={product}
       context="product_edit"
+      csrfToken={csrfToken}
     />
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import csrf from 'edge-csrf';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const csrfProtect = csrf({
+    cookie: {
+        sameSite: 'none',
+    }
+});
+
+export async function middleware(request: NextRequest) {
+    const response = NextResponse.next();
+
+    const csrfError = await csrfProtect(request, response);
+
+    if (csrfError) {
+        return new NextResponse('invalid csrf token', { status: 403 });
+    }
+
+    return response;
+}
+
+export const config = {
+    matcher: ['/productDescription/:productId*', '/api/generateDescription'],
+}


### PR DESCRIPTION
## What? [DATA-11515](https://bigcommercecloud.atlassian.net/browse/DATA-11515)
Per title

## Why?
Since this app is intended to be used as an example for further similar apps, we need to add an example of csrf protection for POST endpoints

## Testing / Proof
Manually tested

@bigcommerce/team-data


[DATA-11515]: https://bigcommercecloud.atlassian.net/browse/DATA-11515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ