### PR TITLE
refactor: DATA-11927 Move to url approach for authorisation

### DIFF
--- a/src/app/api/app/auth/route.ts
+++ b/src/app/api/app/auth/route.ts
@@ -1,4 +1,3 @@
-import jwt from 'jsonwebtoken';
 import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import * as db from '~/lib/db';
@@ -96,17 +95,8 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  const clientToken = jwt.sign(
-    { userId: oauthUser.id, storeHash },
-    env.JWT_KEY,
-    { expiresIn: 3600 }
-  );
-
   return NextResponse.redirect(env.APP_ORIGIN, {
     status: 302,
     statusText: 'Found',
-    headers: {
-      'set-cookie': `ai-app-foundation-token=${clientToken}; SameSite=None; Secure; Path=/; Partitioned; HttpOnly; Max-Age=3600;`,
-    },
   });
 }

--- a/src/app/api/app/load/route.ts
+++ b/src/app/api/app/load/route.ts
@@ -29,6 +29,12 @@ const jwtSchema = z.object({
 });
 
 export function GET(request: NextRequest) {
+  function appendAuthToken(url: string, authToken: string): string {
+    const delimiter = new URL(url, env.APP_ORIGIN).search ? '&' : '?';
+
+    return `${url}${delimiter}authToken=${authToken}`;
+  }
+
   const parsedParams = queryParamSchema.safeParse(
     Object.fromEntries(request.nextUrl.searchParams)
   );
@@ -56,11 +62,8 @@ export function GET(request: NextRequest) {
     expiresIn: 3600,
   });
 
-  return NextResponse.redirect(new URL(path, env.APP_ORIGIN), {
+  return NextResponse.redirect(new URL(appendAuthToken(path, clientToken), env.APP_ORIGIN), {
     status: 302,
     statusText: 'Found',
-    headers: {
-      'set-cookie': `ai-app-foundation-token=${clientToken}; SameSite=None; Secure; Path=/; Partitioned; HttpOnly; Max-Age=3600;`,
-    },
   });
 }

--- a/src/app/api/generateDescription/route.ts
+++ b/src/app/api/generateDescription/route.ts
@@ -4,7 +4,9 @@ import { aiSchema } from './schema';
 import { authorize } from '~/lib/authorize';
 
 export async function POST(req: NextRequest) {
-  if (!authorize()) {
+  const authToken = req.nextUrl.searchParams.get('authToken') || 'missing';
+
+  if (!authorize(authToken)) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 

--- a/src/app/productDescription/[productId]/form.tsx
+++ b/src/app/productDescription/[productId]/form.tsx
@@ -12,7 +12,15 @@ import Loader from '~/components/Loader';
 import { useAppContext } from '~/context/AppContext';
 import { useTracking } from '~/hooks/useTracking';
 
-export default function Form({ product, csrfToken }: { product: Product | NewProduct; csrfToken: string }) {
+export default function Form({
+  product,
+  csrfToken,
+  authToken
+}: {
+  product: Product | NewProduct;
+  csrfToken: string;
+  authToken: string;
+}) {
   const { descriptions, addDescriptionToHistory, updateDescriptionInHistory } =
     useDescriptionsHistory(product.id);
   const [isLoading, setIsLoading] = useState(false);
@@ -35,7 +43,7 @@ export default function Form({ product, csrfToken }: { product: Product | NewPro
 
   const handleGenerateDescription = async () => {
     setIsLoading(true);
-    const res = await fetch('/api/generateDescription', {
+    const res = await fetch(`/api/generateDescription?authToken=${authToken}`, {
       method: 'POST',
       body: JSON.stringify(
         prepareAiPromptAttributes(currentAttributes, product)

--- a/src/app/productDescription/[productId]/generator.tsx
+++ b/src/app/productDescription/[productId]/generator.tsx
@@ -12,13 +12,15 @@ export default function Generator({
   storeHash,
   locale,
   context,
-  csrfToken
+  csrfToken,
+  authToken
 }: {
   product: Product | NewProduct;
   storeHash: string;
   locale: string;
   context: string;
   csrfToken: string;
+  authToken: string;
 }) {
   const [isClient, setIsClient] = useState(false);
 
@@ -33,7 +35,7 @@ export default function Generator({
       {isClient && (
         <AppContext.Provider value={{ locale, storeHash, context }}>
           <PromptAttributesProvider>
-            <Form product={product} csrfToken={csrfToken} />
+            <Form product={product} csrfToken={csrfToken} authToken={authToken} />
           </PromptAttributesProvider>
         </AppContext.Provider>
       )}

--- a/src/app/productDescription/[productId]/page.tsx
+++ b/src/app/productDescription/[productId]/page.tsx
@@ -6,14 +6,14 @@ import { headers } from 'next/headers';
 
 interface PageProps {
   params: { productId: string };
-  searchParams: { product_name: string };
+  searchParams: { product_name: string; authToken: string };
 }
 
 export default async function Page(props: PageProps) {
   const { productId } = props.params;
-  const { product_name: name } = props.searchParams;
+  const { product_name: name, authToken } = props.searchParams;
 
-  const authorized = authorize();
+  const authorized = authorize(authToken);
 
   if (!authorized) {
     throw new Error('Token is not valid. Try to re-open the app.');
@@ -42,6 +42,7 @@ export default async function Page(props: PageProps) {
       product={product}
       context="product_edit"
       csrfToken={csrfToken}
+      authToken={authToken}
     />
   );
 }

--- a/src/lib/authorize.ts
+++ b/src/lib/authorize.ts
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-import { cookies } from 'next/headers';
 import { z } from 'zod';
 import { env } from 'src/env.mjs';
 
@@ -8,15 +7,9 @@ const jwtPayloadSchema = z.object({
   storeHash: z.string(),
 });
 
-export function authorize() {
-  const token = cookies().get('ai-app-foundation-token');
-
-  if (!token) {
-    return null;
-  }
-
+export function authorize(authToken: string) {
   try {
-    const payload = jwt.verify(token.value, env.JWT_KEY);
+    const payload = jwt.verify(authToken, env.JWT_KEY);
 
     const parsed = jwtPayloadSchema.safeParse(payload);
 


### PR DESCRIPTION
## What?
- Move to url approach for authorisation
- Fix redirect issue on the app's page that we previously had in https://github.com/bigcommerce/ai-app-foundation/pull/46

## Why?
Google Chrome has started blocking third-party cookies for some people, and they plan to do this for everyone by the end of 2024. So that we need to switch to another approach for authorisation without using these cookies.
Reference: https://developer.bigcommerce.com/resource-hub/navigating-the-end-of-third-party-cookies-a-guide-for-bigcommerce-app

With this change we are moving to url parameters approach rather than setting token in cookies

## Testing / Proof
Tested locally:
- Ran the app locally
- Tested install/uninstall/reinstall flow
- Tested the panel loading flow
- Tested the description generation flow
- In addition, tested the flow when we first install the old version and then switch to the new one. Thus verified that it still works for users who previously installed the app

@bigcommerce/team-data
