### PR TITLE
feat: CPX-632 add CSP with frame-ancestors

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,27 @@ const csrfProtect = csrf({
 });
 
 export async function middleware(request: NextRequest) {
-    const response = NextResponse.next();
+    const cspHeader = `
+        frame-ancestors https://*.mybigcommerce.com
+        https://*.my-integration.zone
+        https://*.my-staging.zone
+    `;
+    const contentSecurityPolicyHeaderValue = cspHeader
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  
+    const requestHeaders = new Headers(request.headers);
+ 
+    requestHeaders.set(
+        'Content-Security-Policy',
+        contentSecurityPolicyHeaderValue
+    );
+    
+    const response = NextResponse.next({
+        request: {
+            headers: requestHeaders,
+        },
+    });
 
     const csrfError = await csrfProtect(request, response);
 
@@ -17,9 +37,10 @@ export async function middleware(request: NextRequest) {
         return new NextResponse('invalid csrf token', { status: 403 });
     }
 
-    return response;
-}
-
-export const config = {
-    matcher: ['/productDescription/:productId*', '/api/generateDescription'],
+    response.headers.set(
+        'Content-Security-Policy',
+        contentSecurityPolicyHeaderValue
+    );
+    
+    return response
 }


### PR DESCRIPTION
## What/Why?
Implement a content security policy where the `frame-ancestors` are configured with a wildcard to only be loaded within BigCommerce iframes..

Modify headers at the edge to incliude the `content-security-policy` header with `frame-ancestors` allowing the three bigcomemrce environments.

## Rollout/Rollback
revert

## Testing
<img width="1484" alt="Screenshot 2024-09-11 at 12 59 45 PM" src="https://github.com/user-attachments/assets/b97a09bb-0ed7-4c8e-a861-bb276392ecc5">


@bigcommerce/team-data
