### PR TITLE
CPX-1133 add matcher to middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,3 +44,17 @@ export async function middleware(request: NextRequest) {
     
     return response
 }
+
+export const config = {
+    matcher: [
+        /*
+        * Match all request paths except for the ones starting with:
+        * - api (API routes)
+        * - _next/static (static files)
+        * - _next/image (image optimization files)
+        * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+        */
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+        '/api/generateDescription',
+    ],
+}


### PR DESCRIPTION
## What/Why?
* Add matcher to middleware.
* Routes that did not require csrf protection were running through middleware, since the token is not available for these we were attempting to decode an empty string, and an error was thrown.

## Rollout/Rollback
revert

## Testing
check to make sure the following error is no longer being thrown:
```
atob() called with invalid base64-encoded data. (Only whitespace, '+', '/', alphanumeric ASCII, and up to two terminal '=' signs when the input data length is divisible by 4 are allowed.)
```

@bigcommerce/team-data
