### PR TITLE
refactor: DATA-12840 Avoid passing auth poken as a part of request query params

### DIFF
--- a/src/app/api/generateDescription/route.ts
+++ b/src/app/api/generateDescription/route.ts
@@ -4,7 +4,7 @@ import { aiSchema } from './schema';
 import { authorize } from '~/lib/authorize';
 
 export async function POST(req: NextRequest) {
-  const authToken = req.nextUrl.searchParams.get('authToken') || 'missing';
+  const authToken = req.headers.get('X-Auth-Token') || 'missing';
 
   if (!authorize(authToken)) {
     return new NextResponse('Unauthorized', { status: 401 });

--- a/src/app/productDescription/[productId]/form.tsx
+++ b/src/app/productDescription/[productId]/form.tsx
@@ -43,13 +43,14 @@ export default function Form({
 
   const handleGenerateDescription = async () => {
     setIsLoading(true);
-    const res = await fetch(`/api/generateDescription?authToken=${authToken}`, {
+    const res = await fetch(`/api/generateDescription`, {
       method: 'POST',
       body: JSON.stringify(
         prepareAiPromptAttributes(currentAttributes, product)
       ),
       headers: {
         'X-CSRF-Token': csrfToken,
+        'X-Auth-Token': authToken,
       },
     });
 

--- a/src/app/productDescription/[productId]/page.tsx
+++ b/src/app/productDescription/[productId]/page.tsx
@@ -6,12 +6,14 @@ import { headers } from 'next/headers';
 
 interface PageProps {
   params: { productId: string };
-  searchParams: { product_name: string; authToken: string };
+  searchParams: { product_name: string; exchangeToken: string };
 }
 
 export default async function Page(props: PageProps) {
   const { productId } = props.params;
-  const { product_name: name, authToken } = props.searchParams;
+  const { product_name: name, exchangeToken } = props.searchParams;
+
+  const authToken = await db.getClientTokenMaybeAndDelete(exchangeToken) || 'missing';
 
   const authorized = authorize(authToken);
 


### PR DESCRIPTION
## What/Why?
We've previously migrated from the approach where we stored auth token in cookies to query params based. Because of the 3rd party cookies deprecation. Now passing the actual token as a part of query params is not safe, so we needed to come up with a more secure approach. Since we use `NextResponse.redirect` method in the `load/route` we can not pass it in headers or request body. So that the new flow is the following
1. Upon hitting the `load` route we still generate the auth token as we did before
2. Then we temporarily store it in firebase. Which in turn returns us a so called `exchangeToken`, by which we can retrieve the actual auth token. It has a short TTL (currently 2 minutes and may be reduced)
3. Then the `NextResponse.redirect` happens as usual though this time we append this temporary exchangeToken to the URL query parameters (it is the only way we can pass something to the next route)
4. This redirects us to the `src/app/productDescription/[productId]/page.tsx` page where we generate the actual form. Here we get the `exchangeToken` from query params and fetch the actual `authToken` from firebase. It can be retrieved only once and then immediately gets removed from firebase. 
5. As a part of this page we render the `Generator` (and then `Form`) component. We pass the token into the component as an attribute (as we previously did)
6. Finally this component needs the token to actually generate descriptions by calling `api/GenerateDescription` route. Previously we passed the token here as a query param too. With this change we pass it in headers instead and get from headers on the API side.

## Rollout/Rollback
Merge/revert

## Testing
- Tested locally with ngrok
- Testing on preview env (in progress)

@bigcommerce/team-data
