### PR TITLE
fix(analytics): DATA-13528 Upgrade BigAI Copywriter model

### DIFF
--- a/src/server/google-ai/index.ts
+++ b/src/server/google-ai/index.ts
@@ -6,7 +6,7 @@ import { VertexAI } from '@google-cloud/vertexai';
 import { type JWTInput } from 'google-auth-library';
 import { sanitizeForPrompt } from '~/lib/prompt-safety';
 
-const MODEL_NAME = 'gemini-2.0-flash';
+const MODEL_NAME = 'gemini-2.5-flash-lite';
 
 export default async function generateDescription(
   attributes: z.infer<typeof aiSchema>


### PR DESCRIPTION
Jira: [DATA-13528](https://bigcommercecloud.atlassian.net/browse/DATA-13528)

## What/Why?
Upgrade BigAI Copywriter model from `gemini-2.0-flash` to `gemini-2.5-flash-lite` because it's been [retired](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions#retired-models) on June 1st.
Google recommends  upgrade to `gemini-3.1-flash-lite` although a Claude analysis recommends better `gemini-2.5-flash-lite` based on:

1. It is Generally Available on Vertex AI. It is a stable, production GA model with a normal SLA. By contrast, gemini-3.1-flash-lite is currently in preview on Vertex. Preview models have no production SLA, can change behavior, and can be retired with shorter notice, which is exactly the failure class we are fixing right now. We should not introduce a preview model into a merchant-facing flow as a same-day hotfix.
2. It is a drop-in change. It uses the same Vertex AI SDK and the same us-central1 region already configured in the app. The fix is a single line (the MODEL_NAME constant). Preview 3.x models are typically served only through the global endpoint, so moving to gemini-3.1-flash-lite could also require changing the location, adding risk to a fast fix.
3. It lowers cost. Per 1M tokens on Vertex AI standard pricing:
  - gemini-2.0-flash (retired): $0.15 input / $0.60 output
  - gemini-2.5-flash-lite: $0.10 input / $0.40 output (about 33% cheaper on both input and output)
  - gemini-3.1-flash-lite: $0.25 input / $1.50 output (more expensive than the retired model: +67% input, +150% output)


## Rollout/Rollback
Revert.

## Testing
- Generate successfully a description text for a product using BigAI Copywriter.

@bigcommerce/team-data


[DATA-13528]: https://bigcommercecloud.atlassian.net/browse/DATA-13528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ