### PR TITLE
APPSEC-1963: config to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2


### PR DESCRIPTION
Jira: [APPSEC-1963](https://bigcommercecloud.atlassian.net/browse/APPSEC-1963)

## What/Why?
Adding config to prevent NPM packages that are at less than 2 days old to reduce the possible of supply chain attacks.

## Rollout/Rollback
Revert this PR.

## Testing
No testing is needed. This is just a config change

[APPSEC-1963]: https://bigcommercecloud.atlassian.net/browse/APPSEC-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ